### PR TITLE
Fix typos

### DIFF
--- a/doc/man/man1/blobdrop.1
+++ b/doc/man/man1/blobdrop.1
@@ -72,7 +72,7 @@ frontend is used in all cases due to limitations of the Wayland protocol.
 This frontend shows an user interface that lists all items. Each item can be conveniently dragged on its own, or alternatively there is a button to drag all items at once.
 
 .SS "immediate"
-This frontend starts the drag operation automatically without showing a GUI inbetween. The user does not need to hold any mouse button and can just move the mouse cursor to the target location and then click once to drop the files.
+This frontend starts the drag operation automatically without showing a GUI in between. The user does not need to hold any mouse button and can just move the mouse cursor to the target location and then click once to drop the files.
 .br
 Due to limitations in Wayland, this option is only available on X11. This option also works over XWayland, but then the target drop location is required to be running in XWayland too. Native Wayland does not have support for this frontend, because the spec requires an implicit grab for native wl_data_device::start_drag() operations, thus making it impossible to implement this workflow on Wayland.
 .br

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -99,7 +99,7 @@ void Backend::send_drag_notification(const QList<QString> &uris) {
 
 void Backend::hide_terminal() {
 #if !defined(Q_OS_WIN) && !defined(Q_OS_DARWIN)
-	if (Settings::get()->supress_always_on_bottom || !xcb.init()) {
+	if (Settings::get()->suppress_always_on_bottom || !xcb.init()) {
 		return;
 	}
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -9,11 +9,11 @@ Settings *Settings::create(QQmlEngine *qmlEngine, QJSEngine *jsEngine) {
 }
 
 void Settings::disable_always_on_bottom() {
-	supress_always_on_bottom = true;
+	suppress_always_on_bottom = true;
 }
 
 void Settings::setAlwaysOnBottom(const bool v) {
-	if (!supress_always_on_bottom) {
+	if (!suppress_always_on_bottom) {
 		always_on_bottom = v;
 		emit alwaysOnBottomChanged(always_on_bottom);
 	}

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -25,7 +25,7 @@ public:
 		Gui, // show a window to drag files from
 		Immediate, // perform drag immediately without needing to hold down the mouse
 		Notification, // show a desktop notification to drag from
-		Stdout, // print a link in the terminal usin OSC8
+		Stdout, // print a link in the terminal using OSC8
 	};
 
 	STRICT_SINGLETON(Settings)
@@ -42,7 +42,7 @@ public:
 	bool keep_dropped_files = false;
 	bool frameless = false;
 	bool can_drag_immediately = false;
-	bool supress_always_on_bottom = false;
+	bool suppress_always_on_bottom = false;
 signals:
 	void alwaysOnBottomChanged(bool alwaysOnBottom);
 	void keepDroppedFilesChanged(bool keepDroppedFiles);


### PR DESCRIPTION
Found via `codespell -H` and `typos --hidden --format brief`